### PR TITLE
Additional pom updates to use JBoss nexus for deploying the jbossorg …

### DIFF
--- a/jaxb-ri/codemodel/pom.xml
+++ b/jaxb-ri/codemodel/pom.xml
@@ -40,6 +40,14 @@
 
         <upper.java.level>9</upper.java.level>
         <base.java.level>8</base.java.level>
+
+        <!-- ***************** -->
+        <!-- Repository Deployment URLs -->
+        <!-- ***************** -->
+        <jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
+        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+        <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
+        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
     </properties>
 
     <modules>
@@ -280,5 +288,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+      <repository>
+        <id>${jboss.releases.repo.id}</id>
+        <name>JBoss Releases Repository</name>
+        <url>${jboss.releases.repo.url}</url>
+      </repository>
+      <snapshotRepository>
+        <id>${jboss.snapshots.repo.id}</id>
+        <name>JBoss Snapshots Repository</name>
+        <url>${jboss.snapshots.repo.url}</url>
+      </snapshotRepository>
+    </distributionManagement>
 
 </project>

--- a/jaxb-ri/external/pom.xml
+++ b/jaxb-ri/external/pom.xml
@@ -42,6 +42,14 @@
 
         <upper.java.level>9</upper.java.level>
         <base.java.level>8</base.java.level>
+
+        <!-- ***************** -->
+        <!-- Repository Deployment URLs -->
+        <!-- ***************** -->
+        <jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
+        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+        <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
+        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
     </properties>
 
     <modules>
@@ -282,5 +290,18 @@
             </plugin>
         </plugins>
     </build>
+
+    <distributionManagement>
+      <repository>
+        <id>${jboss.releases.repo.id}</id>
+        <name>JBoss Releases Repository</name>
+        <url>${jboss.releases.repo.url}</url>
+      </repository>
+      <snapshotRepository>
+        <id>${jboss.snapshots.repo.id}</id>
+        <name>JBoss Snapshots Repository</name>
+        <url>${jboss.snapshots.repo.url}</url>
+      </snapshotRepository>
+    </distributionManagement>
 
 </project>

--- a/jaxb-ri/xsom/pom.xml
+++ b/jaxb-ri/xsom/pom.xml
@@ -45,6 +45,14 @@
         <relaxng.version>2.3.2</relaxng.version>
         <upper.java.level>9</upper.java.level>
         <base.java.level>8</base.java.level>
+
+        <!-- ***************** -->
+        <!-- Repository Deployment URLs -->
+        <!-- ***************** -->
+        <jboss.releases.repo.id>jboss-releases-repository</jboss.releases.repo.id>
+        <jboss.releases.repo.url>https://repository.jboss.org/nexus/service/local/staging/deploy/maven2/</jboss.releases.repo.url>
+        <jboss.snapshots.repo.id>jboss-snapshots-repository</jboss.snapshots.repo.id>
+        <jboss.snapshots.repo.url>https://repository.jboss.org/nexus/content/repositories/snapshots/</jboss.snapshots.repo.url>
     </properties>
 
     <dependencies>
@@ -370,4 +378,17 @@
         <!--</profile>-->
 
     </profiles>
+
+    <distributionManagement>
+      <repository>
+        <id>${jboss.releases.repo.id}</id>
+        <name>JBoss Releases Repository</name>
+        <url>${jboss.releases.repo.url}</url>
+      </repository>
+      <snapshotRepository>
+        <id>${jboss.snapshots.repo.id}</id>
+        <name>JBoss Snapshots Repository</name>
+        <url>${jboss.snapshots.repo.url}</url>
+      </snapshotRepository>
+    </distributionManagement>
 </project>


### PR DESCRIPTION
…release

More than one pom in the repo depends on external poms as its base, so they all need the distrbibutionManagement setting

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>